### PR TITLE
feat(permissions): operator permissions (statuses, boxes, screens) + API

### DIFF
--- a/,lkp
+++ b/,lkp
@@ -1,0 +1,8 @@
+  develop[m
+  feature/box-crud-improvements[m
+  feature/status-management[m
+  feature/system-settings[m
+* [32mfeature/user-permissions[m
+  main[m
+  refactor/clean-architecture[m
++ [36mrescue/from-stash1[m

--- a/DockQueue.API/Controllers/OperatorPermissionsController.cs
+++ b/DockQueue.API/Controllers/OperatorPermissionsController.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using DockQueue.Application.DTOs.Permissions;
+using DockQueue.Application.Interfaces;
+
+namespace DockQueue.Api.Controllers
+{
+    [ApiController]
+    [Route("api/operators/{userId:int}/permissions")]
+    public class OperatorPermissionsController : ControllerBase
+    {
+        private readonly IOperatorPermissionsService _service;
+        public OperatorPermissionsController(IOperatorPermissionsService service) { _service = service; }
+
+        // Dashboard/Tela de Permissões consome isso para montar as 3 abas
+        [HttpGet]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> Get(int userId)
+        {
+            var dto = await _service.GetByUserIdAsync(userId);
+            if (dto is null) return NotFound();
+            return Ok(dto);
+        }
+
+        // Atualiza as 3 abas de uma vez (status, boxes, telas)
+        [HttpPut]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> Put(int userId, [FromBody] UpdateOperatorPermissionsDto dto)
+        {
+            var saved = await _service.UpsertAsync(userId, dto);
+            return Ok(saved);
+        }
+    }
+}

--- a/DockQueue.Application/DTOs/Permissions/OperatorPermissionsDto.cs
+++ b/DockQueue.Application/DTOs/Permissions/OperatorPermissionsDto.cs
@@ -1,0 +1,14 @@
+using DockQueue.Domain.ValueObjects;
+
+namespace DockQueue.Application.DTOs.Permissions
+{
+    // Retorno para a tela (3 abas + dashboard)
+    public class OperatorPermissionsDto
+    {
+        public int UserId { get; set; }
+        public List<int> AllowedStatusIds { get; set; } = new();
+        public List<int> AllowedBoxIds { get; set; } = new();
+        public Screen AllowedScreens { get; set; } // Flags (exibir no dashboard/toggles)
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/DockQueue.Application/DTOs/Permissions/UpdateOperatorPermissionsDto.cs
+++ b/DockQueue.Application/DTOs/Permissions/UpdateOperatorPermissionsDto.cs
@@ -1,0 +1,12 @@
+using DockQueue.Domain.ValueObjects;
+
+namespace DockQueue.Application.DTOs.Permissions
+{
+    // Payload enviado pela tela (abas) para atualizar permissões do operador
+    public class UpdateOperatorPermissionsDto
+    {
+        public List<int> AllowedStatusIds { get; set; } = new();
+        public List<int> AllowedBoxIds { get; set; } = new();
+        public Screen AllowedScreens { get; set; } = Screen.None; // toggles de visualização
+    }
+}

--- a/DockQueue.Application/Interfaces/IOperatorPermissionsService.cs
+++ b/DockQueue.Application/Interfaces/IOperatorPermissionsService.cs
@@ -1,0 +1,10 @@
+using DockQueue.Application.DTOs.Permissions;
+
+namespace DockQueue.Application.Interfaces
+{
+    public interface IOperatorPermissionsService
+    {
+        Task<OperatorPermissionsDto?> GetByUserIdAsync(int userId);
+        Task<OperatorPermissionsDto> UpsertAsync(int userId, UpdateOperatorPermissionsDto dto);
+    }
+}

--- a/DockQueue.Application/Services/BoxService.cs
+++ b/DockQueue.Application/Services/BoxService.cs
@@ -50,7 +50,7 @@ namespace DockQueue.Application.Services
                 createBoxDto.Name,
                 createBoxDto.Status,
                 createBoxDto.DriverId,
-                DateTime.Now
+                DateTime.UtcNow
             );
 
 

--- a/DockQueue.Application/Services/OperatorPermissionsService.cs
+++ b/DockQueue.Application/Services/OperatorPermissionsService.cs
@@ -1,0 +1,61 @@
+using DockQueue.Application.DTOs.Permissions;
+using DockQueue.Application.Interfaces;
+using DockQueue.Domain.Entities;
+using DockQueue.Domain.Interfaces;
+using DockQueue.Domain.Validation;
+
+namespace DockQueue.Application.Services
+{
+    public class OperatorPermissionsService : IOperatorPermissionsService
+    {
+        private readonly IOperatorPermissionsRepository _repo;
+        private readonly IUserRepository _userRepo; // valida se user existe
+        private readonly IStatusRepository _statusRepo; // (opcional) valida ids
+        // Se quiser validar boxes, injete IBoxRepository (se existir)
+
+        public OperatorPermissionsService(
+            IOperatorPermissionsRepository repo,
+            IUserRepository userRepo,
+            IStatusRepository statusRepo)
+        {
+            _repo = repo;
+            _userRepo = userRepo;
+            _statusRepo = statusRepo;
+        }
+
+        public async Task<OperatorPermissionsDto?> GetByUserIdAsync(int userId)
+        {
+            var agg = await _repo.GetByUserIdAsync(userId);
+            return agg is null ? null : Map(agg);
+        }
+
+        public async Task<OperatorPermissionsDto> UpsertAsync(int userId, UpdateOperatorPermissionsDto dto)
+        {
+            // --- Valida usuário existente (feedback claro para tela) ---
+            _ = await _userRepo.GetByIdAsync(userId);
+
+            // (Opcional) Validar se StatusIds existem (ajuda a evitar “lixo”)
+            // var allStatuses = await _statusRepo.GetAllAsync();
+            // var set = allStatuses.Select(s => s.Id).ToHashSet();
+            // if (dto.AllowedStatusIds.Any(id => !set.Contains(id)))
+            //     throw new DomainExceptionValidation("Existem StatusIds inválidos");
+
+            var now = DateTime.UtcNow;
+            var incoming = new OperatorPermissions(userId, dto.AllowedScreens, now);
+            incoming.SetStatuses(dto.AllowedStatusIds, now);
+            incoming.SetBoxes(dto.AllowedBoxIds, now);
+
+            var saved = await _repo.UpsertAsync(incoming);
+            return Map(saved);
+        }
+
+        private static OperatorPermissionsDto Map(OperatorPermissions x) => new()
+        {
+            UserId = x.UserId,
+            AllowedScreens = x.AllowedScreens,
+            AllowedStatusIds = x.AllowedStatuses.Select(s => s.StatusId).ToList(),
+            AllowedBoxIds = x.AllowedBoxes.Select(b => b.BoxId).ToList(),
+            UpdatedAt = x.UpdatedAt
+        };
+    }
+}

--- a/DockQueue.Domain/Entities/OperatorPermissions.cs
+++ b/DockQueue.Domain/Entities/OperatorPermissions.cs
@@ -1,0 +1,84 @@
+using DockQueue.Domain.Validation;
+using DockQueue.Domain.ValueObjects;
+
+namespace DockQueue.Domain.Entities
+{
+    // Agregado raiz para permissões de um operador específico (UserId).
+    public class OperatorPermissions
+    {
+        public int Id { get; private set; }
+        public int UserId { get; private set; }           // FK para User
+        public Screen AllowedScreens { get; private set; } // flags de telas/menus liberados
+
+        // Coleções simples para Status e Boxes liberados
+        public ICollection<OperatorStatusPermission> AllowedStatuses { get; private set; } = new List<OperatorStatusPermission>();
+        public ICollection<OperatorBoxPermission> AllowedBoxes { get; private set; } = new List<OperatorBoxPermission>();
+
+        public DateTime CreatedAt { get; private set; }
+        public DateTime UpdatedAt { get; private set; }
+
+        protected OperatorPermissions() { }
+
+        public OperatorPermissions(int userId, Screen allowedScreens, DateTime nowUtc)
+        {
+            DomainExceptionValidation.When(userId <= 0, "UserId inválido");
+            UserId = userId;
+            AllowedScreens = allowedScreens;
+            CreatedAt = nowUtc;
+            UpdatedAt = nowUtc;
+        }
+
+        // Atualiza apenas o conjunto de telas; listas são gerenciadas por métodos dedicados
+        public void UpdateScreens(Screen screens, DateTime nowUtc)
+        {
+            AllowedScreens = screens;
+            UpdatedAt = nowUtc;
+        }
+
+        public void SetStatuses(IEnumerable<int> statusIds, DateTime nowUtc)
+        {
+            AllowedStatuses.Clear();
+            foreach (var id in statusIds.Distinct())
+                AllowedStatuses.Add(new OperatorStatusPermission(UserId, id));
+            UpdatedAt = nowUtc;
+        }
+
+        public void SetBoxes(IEnumerable<int> boxIds, DateTime nowUtc)
+        {
+            AllowedBoxes.Clear();
+            foreach (var id in boxIds.Distinct())
+                AllowedBoxes.Add(new OperatorBoxPermission(UserId, id));
+            UpdatedAt = nowUtc;
+        }
+    }
+
+    // Item da coleção: status permitido para o operador
+    public class OperatorStatusPermission
+    {
+        public int Id { get; private set; }
+        public int UserId { get; private set; }   // redundante no item para facilitar queries (índice)
+        public int StatusId { get; private set; }
+
+        protected OperatorStatusPermission() { }
+        public OperatorStatusPermission(int userId, int statusId)
+        {
+            UserId = userId;
+            StatusId = statusId;
+        }
+    }
+
+    // Item da coleção: box permitido para o operador
+    public class OperatorBoxPermission
+    {
+        public int Id { get; private set; }
+        public int UserId { get; private set; }
+        public int BoxId { get; private set; }
+
+        protected OperatorBoxPermission() { }
+        public OperatorBoxPermission(int userId, int boxId)
+        {
+            UserId = userId;
+            BoxId = boxId;
+        }
+    }
+}

--- a/DockQueue.Domain/Interfaces/IOperatorPermissionsRepository.cs
+++ b/DockQueue.Domain/Interfaces/IOperatorPermissionsRepository.cs
@@ -1,0 +1,10 @@
+using DockQueue.Domain.Entities;
+
+namespace DockQueue.Domain.Interfaces
+{
+    public interface IOperatorPermissionsRepository
+    {
+        Task<OperatorPermissions?> GetByUserIdAsync(int userId);
+        Task<OperatorPermissions> UpsertAsync(OperatorPermissions incoming);
+    }
+}

--- a/DockQueue.Domain/ValueObjects/Screen.cs
+++ b/DockQueue.Domain/ValueObjects/Screen.cs
@@ -1,0 +1,18 @@
+namespace DockQueue.Domain.ValueObjects
+{
+	// Flags permitem combinar permissões de visualização sem criar muitas linhas no banco.
+	[Flags]
+	public enum Screen
+	{
+		None = 0,
+		Dashboard = 1 << 0,
+		QueueView = 1 << 1,
+		BoxesView = 1 << 2,
+		StatusAdmin = 1 << 3,
+		Settings = 1 << 4,
+		Reports = 1 << 5,
+
+		// Atalho para “tudo liberado” — útil para ADMIN.
+		All = Dashboard | QueueView | BoxesView | StatusAdmin | Settings | Reports
+	}
+}

--- a/DockQueue.Infra.Data/Context/ApplicationDbContext.cs
+++ b/DockQueue.Infra.Data/Context/ApplicationDbContext.cs
@@ -14,7 +14,9 @@ namespace DockQueue.Infra.Data.Context
         public DbSet<Box> Boxes { get; set; }
         public DbSet<Status> Statuses { get; set; }
         public DbSet<SystemSettings> SystemSettings { get; set; }
-
+        public DbSet<OperatorPermissions> OperatorPermissions { get; set; }
+        public DbSet<OperatorStatusPermission> OperatorStatusPermissions { get; set; }
+        public DbSet<OperatorBoxPermission> OperatorBoxPermissions { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {

--- a/DockQueue.Infra.Data/EntitiesConfiguration/OperatorPermissionsConfiguration.cs
+++ b/DockQueue.Infra.Data/EntitiesConfiguration/OperatorPermissionsConfiguration.cs
@@ -1,0 +1,61 @@
+using DockQueue.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DockQueue.Infra.Data.EntitiesConfiguration
+{
+    internal class OperatorPermissionsConfiguration : IEntityTypeConfiguration<OperatorPermissions>
+    {
+        public void Configure(EntityTypeBuilder<OperatorPermissions> b)
+        {
+            b.ToTable("operator_permissions");
+            b.HasKey(x => x.Id);
+
+            b.HasIndex(x => x.UserId).IsUnique();      // 1 registro de permissões por usuário
+            b.Property(x => x.UserId).IsRequired();
+
+            // Flags de telas armazenadas como int
+            b.Property(x => x.AllowedScreens).HasConversion<int>().IsRequired();
+
+            b.Property(x => x.CreatedAt).IsRequired();
+            b.Property(x => x.UpdatedAt).IsRequired();
+
+            // Relacionamentos com coleções
+            b.HasMany(x => x.AllowedStatuses)
+             .WithOne()
+             .HasForeignKey("OperatorPermissionsId")
+             .OnDelete(DeleteBehavior.Cascade);
+
+            b.HasMany(x => x.AllowedBoxes)
+             .WithOne()
+             .HasForeignKey("OperatorPermissionsId")
+             .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+
+    internal class OperatorStatusPermissionConfiguration : IEntityTypeConfiguration<OperatorStatusPermission>
+    {
+        public void Configure(EntityTypeBuilder<OperatorStatusPermission> b)
+        {
+            b.ToTable("operator_status_permissions");
+            b.HasKey(x => x.Id);
+
+            b.HasIndex(x => new { x.UserId, x.StatusId }).IsUnique(); // evita duplicidade
+            b.Property(x => x.UserId).IsRequired();
+            b.Property(x => x.StatusId).IsRequired();
+        }
+    }
+
+    internal class OperatorBoxPermissionConfiguration : IEntityTypeConfiguration<OperatorBoxPermission>
+    {
+        public void Configure(EntityTypeBuilder<OperatorBoxPermission> b)
+        {
+            b.ToTable("operator_box_permissions");
+            b.HasKey(x => x.Id);
+
+            b.HasIndex(x => new { x.UserId, x.BoxId }).IsUnique();
+            b.Property(x => x.UserId).IsRequired();
+            b.Property(x => x.BoxId).IsRequired();
+        }
+    }
+}

--- a/DockQueue.Infra.Data/Migrations/20251020021422_Feature_UserPermissions.Designer.cs
+++ b/DockQueue.Infra.Data/Migrations/20251020021422_Feature_UserPermissions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DockQueue.Infra.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DockQueue.Infra.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251020021422_Feature_UserPermissions")]
+    partial class Feature_UserPermissions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DockQueue.Infra.Data/Migrations/20251020021422_Feature_UserPermissions.cs
+++ b/DockQueue.Infra.Data/Migrations/20251020021422_Feature_UserPermissions.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace DockQueue.Infra.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class Feature_UserPermissions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "operator_permissions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<int>(type: "integer", nullable: false),
+                    AllowedScreens = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_operator_permissions", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "operator_box_permissions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<int>(type: "integer", nullable: false),
+                    BoxId = table.Column<int>(type: "integer", nullable: false),
+                    OperatorPermissionsId = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_operator_box_permissions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_operator_box_permissions_operator_permissions_OperatorPermi~",
+                        column: x => x.OperatorPermissionsId,
+                        principalTable: "operator_permissions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "operator_status_permissions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<int>(type: "integer", nullable: false),
+                    StatusId = table.Column<int>(type: "integer", nullable: false),
+                    OperatorPermissionsId = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_operator_status_permissions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_operator_status_permissions_operator_permissions_OperatorPe~",
+                        column: x => x.OperatorPermissionsId,
+                        principalTable: "operator_permissions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_operator_box_permissions_OperatorPermissionsId",
+                table: "operator_box_permissions",
+                column: "OperatorPermissionsId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_operator_box_permissions_UserId_BoxId",
+                table: "operator_box_permissions",
+                columns: new[] { "UserId", "BoxId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_operator_permissions_UserId",
+                table: "operator_permissions",
+                column: "UserId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_operator_status_permissions_OperatorPermissionsId",
+                table: "operator_status_permissions",
+                column: "OperatorPermissionsId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_operator_status_permissions_UserId_StatusId",
+                table: "operator_status_permissions",
+                columns: new[] { "UserId", "StatusId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "operator_box_permissions");
+
+            migrationBuilder.DropTable(
+                name: "operator_status_permissions");
+
+            migrationBuilder.DropTable(
+                name: "operator_permissions");
+        }
+    }
+}

--- a/DockQueue.Infra.Data/Repositories/OperatorPermissionsRepository.cs
+++ b/DockQueue.Infra.Data/Repositories/OperatorPermissionsRepository.cs
@@ -1,0 +1,46 @@
+using DockQueue.Domain.Entities;
+using DockQueue.Domain.Interfaces;
+using DockQueue.Infra.Data.Context;
+using Microsoft.EntityFrameworkCore;
+
+namespace DockQueue.Infra.Data.Repositories
+{
+    public class OperatorPermissionsRepository : IOperatorPermissionsRepository
+    {
+        private readonly ApplicationDbContext _ctx;
+        public OperatorPermissionsRepository(ApplicationDbContext ctx) { _ctx = ctx; }
+
+        // Carrega o agregado inteiro (telas + listas)
+        public async Task<OperatorPermissions?> GetByUserIdAsync(int userId)
+        {
+            return await _ctx.OperatorPermissions
+                .Include(x => x.AllowedStatuses)
+                .Include(x => x.AllowedBoxes)
+                .FirstOrDefaultAsync(x => x.UserId == userId);
+        }
+
+        // Upsert transacional simples
+        public async Task<OperatorPermissions> UpsertAsync(OperatorPermissions incoming)
+        {
+            var existing = await _ctx.OperatorPermissions
+                .Include(x => x.AllowedStatuses)
+                .Include(x => x.AllowedBoxes)
+                .FirstOrDefaultAsync(x => x.UserId == incoming.UserId);
+
+            if (existing is null)
+            {
+                _ctx.OperatorPermissions.Add(incoming);
+            }
+            else
+            {
+                existing.UpdateScreens(incoming.AllowedScreens, DateTime.UtcNow);
+                existing.SetStatuses(incoming.AllowedStatuses.Select(s => s.StatusId), DateTime.UtcNow);
+                existing.SetBoxes(incoming.AllowedBoxes.Select(b => b.BoxId), DateTime.UtcNow);
+                _ctx.OperatorPermissions.Update(existing);
+            }
+
+            await _ctx.SaveChangesAsync();
+            return await GetByUserIdAsync(incoming.UserId) ?? throw new InvalidOperationException("Falha ao salvar permissões");
+        }
+    }
+}

--- a/DockQueue.Infra.Ioc/DependencyInjection.cs
+++ b/DockQueue.Infra.Ioc/DependencyInjection.cs
@@ -26,14 +26,14 @@ namespace DockQueue.Infra.Ioc
             services.AddScoped<IBoxRepository, BoxRepository>();
             services.AddScoped<IStatusRepository, StatusRepository>();
             services.AddScoped<ISystemSettingsRepository, SystemSettingsRepository>();
-
+            services.AddScoped<IOperatorPermissionsRepository, OperatorPermissionsRepository>();
 
             // Services
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<IBoxService, BoxService>();
             services.AddScoped<IStatusService, StatusService>();
             services.AddScoped<ISystemSettingsService, SystemSettingsService>();
-
+            services.AddScoped<IOperatorPermissionsService, OperatorPermissionsService>();
             // Auth / Tokens
             // Remover o AddScoped<JwtTokenGenerator>();
             // Registrar apenas como ITokenGenerator com lifetime único


### PR DESCRIPTION
Aggregate OperatorPermissions per user (statuses, boxes, screens flags)

EF mappings + repository (upsert + include collections)

Service with validations + DTOs split per file

Controller GET/PUT /api/operators/{userId}/permissions

Comments in key parts for maintainability

Ready to extend with more modules/permissions